### PR TITLE
fix bug in #6 Bug about tensor type mismatch

### DIFF
--- a/hyperbox/mutables/spaces.py
+++ b/hyperbox/mutables/spaces.py
@@ -98,7 +98,6 @@ class Mutable(nn.Module):
             if getattr(self, 'verbose_freeze', False):
                 print(f"{attribute} has been forzen, you should call `defrost` function before you modify it.")
         else:
-            # self.__dict__[attribute] = value
             super(Mutable, self).__setattr__(attribute, value)
 
     def freeze(self, attribute=None, verbose=False):


### PR DESCRIPTION
Setattr function in PyTorch would register the operations to self._modules. When we run model.cuda(), operations in module._modules will be transfered to GPU.

To fix this bug, we should pass the parameters of Mutable to `nn.Module`.

old: 

```
class Mutable(nn.Module):
    """
    Mutable is designed to function as a normal layer, with all necessary operators' weights.
    States and weights of architectures should be included in mutator, instead of the layer itself.

    Mutable has a key, which marks the identity of the mutable. This key can be used by users to share
    decisions among different mutables. In mutator's implementation, mutators should use the key to
    distinguish different mutables. Mutables that share the same key should be "similar" to each other.

    Currently the default scope for keys is global.
    """ 

    def __setattr__(self, attribute, value):
        if getattr(self, 'is_freeze', False) and \
            attribute in getattr(self, 'frozen_attributes', []):
            if getattr(self, 'verbose_freeze', False):
                print(f"{attribute} has been forzen, you should call `defrost` function before you modify it.")
        else:
            self.__dict__[attribute] = value
```

new: 

```
class Mutable(nn.Module):
    """
    Mutable is designed to function as a normal layer, with all necessary operators' weights.
    States and weights of architectures should be included in mutator, instead of the layer itself.

    Mutable has a key, which marks the identity of the mutable. This key can be used by users to share
    decisions among different mutables. In mutator's implementation, mutators should use the key to
    distinguish different mutables. Mutables that share the same key should be "similar" to each other.

    Currently the default scope for keys is global.
    """ 

    def __setattr__(self, attribute, value):
        if getattr(self, 'is_freeze', False) and \
            attribute in getattr(self, 'frozen_attributes', []):
            if getattr(self, 'verbose_freeze', False):
                print(f"{attribute} has been forzen, you should call `defrost` function before you modify it.")
        else:
            super(Mutable, self).__setattr__(attribute, value)
```
